### PR TITLE
origin_check to check_origin

### DIFF
--- a/jupyter_server_terminals_proxy/handlers.py
+++ b/jupyter_server_terminals_proxy/handlers.py
@@ -19,8 +19,8 @@ class TermSocket(WebSocketHandler, JupyterHandler):
         super().__init__(*args, **kwargs)
         self.websocket = None
 
-    def origin_check(self):
-        return False
+    def check_origin(self, origin):
+        return True
 
     def get(self, *args, **kwargs):
         user = self.current_user


### PR DESCRIPTION
This seems to be a typo
https://www.tornadoweb.org/en/stable/websocket.html#tornado.websocket.WebSocketHandler.check_origin